### PR TITLE
Minor fixes in scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# VS Code 
+.vscode

--- a/scripts/logo.py
+++ b/scripts/logo.py
@@ -1,4 +1,7 @@
-from fibermat import *
+import matplotlib.pyplot as plt
+import numpy as np
+
+from fibermat import Mat, Mesh, Net, Stack, Timoshenko, solve, vtk_mesh
 
 mask = np.array(
     [
@@ -38,23 +41,19 @@ net = Net(mat, periodic=False)
 stack = Stack(net)
 # Create the fiber mesh
 mesh = Mesh(stack)
+# Instantiate model
+model = Timoshenko(mesh)
 
 # Solve the mechanical packing problem
-K, C, u, f, F, H, Z, rlambda, mask, err = solve(
-    mesh,
-    stiffness(mesh),
-    constraint(mesh),
-    packing=4,
-    itermax=10000
-)
+solution = solve(model, packing=4, itermax=10000)
 
 # Export as VTK
 msh = vtk_mesh(
     mesh,
-    displacement(u(1)),
-    rotation(u(1)),
-    force(f(1) @ C),
-    torque(f(1) @ C),
+    solution.displacement(1),
+    solution.rotation(1),
+    solution.force(1),
+    solution.torque(1),
 )
 msh.plot(scalars="force", cmap=plt.cm.twilight_shifted)
 # msh.save("outputs/msh.vtk")

--- a/scripts/square.py
+++ b/scripts/square.py
@@ -5,33 +5,27 @@ from matplotlib import pyplot as plt
 
 from fibermat import Mat, Mesh, Net, Stack, Timoshenko, solve, vtk_mesh
 
-################################################################################
-# Main
-################################################################################
+# Generate a set of fibers
+mat = Mat(3000, length=4, width=0.2, thickness=0.05, size=40, tensile=1600)
+# Build the fiber network
+net = Net(mat, periodic=True)
+# Stack fibers
+stack = Stack(net, threshold=1)
+# Create the fiber mesh
+mesh = Mesh(stack)
+# Instantiate model
+model = Timoshenko(mesh)
 
-if __name__ == "__main__":
+# Solve the mechanical packing problem
+solution = solve(model, packing=4, itermax=10000)
 
-    # Generate a set of fibers
-    mat = Mat(3000, length=4, width=0.2, thickness=0.05, size=40, tensile=1600)
-    # Build the fiber network
-    net = Net(mat, periodic=True)
-    # Stack fibers
-    stack = Stack(net, threshold=1)
-    # Create the fiber mesh
-    mesh = Mesh(stack)
-    # Instanciate model
-    model = Timoshenko(mesh)
-
-    # Solve the mechanical packing problem
-    solution = solve(model, packing=4, itermax=10000)
-
-    # Export as VTK
-    msh = vtk_mesh(
-        mesh,
-        solution.displacement(1),
-        solution.rotation(1),
-        solution.force(1),
-        solution.torque(1),
-    )
-    msh.plot(scalars="force", cmap=plt.cm.twilight_shifted)
-    # msh.save("outputs/msh.vtk")
+# Export as VTK
+msh = vtk_mesh(
+    mesh,
+    solution.displacement(1),
+    solution.rotation(1),
+    solution.force(1),
+    solution.torque(1),
+)
+msh.plot(scalars="force", cmap=plt.cm.twilight_shifted)
+# msh.save("outputs/msh.vtk")

--- a/scripts/square.py
+++ b/scripts/square.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import numpy as np
 from matplotlib import pyplot as plt
 
-from fibermat import *
-
+from fibermat import Mat, Mesh, Net, Stack, Timoshenko, solve, vtk_mesh
 
 ################################################################################
 # Main
@@ -21,21 +19,19 @@ if __name__ == "__main__":
     stack = Stack(net, threshold=1)
     # Create the fiber mesh
     mesh = Mesh(stack)
+    # Instanciate model
+    model = Timoshenko(mesh)
 
     # Solve the mechanical packing problem
-    K, C, u, f, F, H, Z, rlambda, mask, err = solve(
-        mesh,
-        packing=4,
-        itermax=10000,
-    )
+    solution = solve(model, packing=4, itermax=10000)
 
     # Export as VTK
     msh = vtk_mesh(
         mesh,
-        displacement(u(1)),
-        rotation(u(1)),
-        force(f(1) @ C),
-        torque(f(1) @ C),
+        solution.displacement(1),
+        solution.rotation(1),
+        solution.force(1),
+        solution.torque(1),
     )
     msh.plot(scalars="force", cmap=plt.cm.twilight_shifted)
     # msh.save("outputs/msh.vtk")


### PR DESCRIPTION
Bonjour François,

Thanks for this nice contribution to the discontinuous fiber community. After seeing your presentation at ECCM, I checked out your repository and noticed that we had to make some minor changes to run the examples in the `script` directory. You may consider this pull request to fix that. 

Cheers,
Nils 

PS: In addition, I started a branch with non-uniform size, i.e. `size` becomes `sizeX`, `sizeY` and `sizeZ`. If you are interested, I can open a separate pull request for that. 